### PR TITLE
Fix composer.json schema

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,6 @@
         "squizlabs/php_codesniffer": "^3.0",
         "phpstan/phpstan": "^0.12"
     },
-    "suggest": [],
     "autoload": {
         "psr-4": {
             "Middlewares\\": "src/"


### PR DESCRIPTION
Fixing `composer.json schema` because of following error message:

```
  [Composer\Json\JsonValidationException]                     
  "./composer.json" does not match the expected JSON schema:  
   - suggest : Array value found, but an object is required
```